### PR TITLE
Fix collapsible template explaination block

### DIFF
--- a/docassemble/MATCTheme/data/questions/questions.yml
+++ b/docassemble/MATCTheme/data/questions/questions.yml
@@ -59,7 +59,7 @@ validation code: |
     validation_error("You must accept the terms of use to continue.", field="acknowledged_information_use")
 ---
 template: explain_how_to_use_collapsible_templates
-question: |
+subject: |
   Click a dotted line with an arrow like this to read longer help information
-subquestion: |
+content: |
   Click the line again to hide the information.


### PR DESCRIPTION
Any interview using MATCTheme on `main` currently will break on the first screen with this error.

```
Interview has an error. There was a reference to a variable 'explain_how_to_use_collapsible_templates' that could not be looked up in the question file (for language 'en') or in any of the files incorporated by reference into the question file.
```

While that template block is present in the `questions.yml`, it needs to use subject and content, not question and subquestion. Fixes error introduced in https://github.com/SuffolkLITLab/docassemble-MATCTheme/pull/10.

Nothing in prod looks like it's broken because the latest version of main hasn't been released yet.