### PR TITLE
Create publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,13 @@
+name: Publish MATCTheme 📦 to PyPI
+
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish MATCTheme 📦 to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: SuffolkLITLab/ALActions/publish@main
+      with:
+        PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        VERSION_TO_PUBLISH: ${{ env.GITHUB_REF_NAME }}


### PR DESCRIPTION
Lets us publish this repo to PyPI, which we should do for dependent / library packages like this one.

Copied directly from https://github.com/SuffolkLITLab/docassemble-MassAccess/blob/main/.github/workflows/publish.yml.

Will make a 1.0.6 release after this is merged.