### PR TITLE
Correct typo on intro screen

### DIFF
--- a/docassemble/MATCTheme/data/questions/questions.yml
+++ b/docassemble/MATCTheme/data/questions/questions.yml
@@ -37,7 +37,7 @@ subquestion: |
   <span class="dachoicehelp text-info">
     <i class="fa fa-circle-question fa-lg"></i>
   </span>
-  icon next to an list of choices to learn more about the option.
+  icon next to a list of choices to learn more about the option.
   
   % if chat_partners_available().help:
   Live help is currently available in this interview. Click the speech bubble


### PR DESCRIPTION
"an list" -> "a list"

Fix #17